### PR TITLE
Fix: Updated ChannelIdKey in Constants.cs for Android to have the upd…

### DIFF
--- a/Plugin.FirebasePushNotifications/Platforms/Android/Constants.cs
+++ b/Plugin.FirebasePushNotifications/Platforms/Android/Constants.cs
@@ -32,7 +32,7 @@
         public const string IconKey = "icon";
         public const string LargeIconKey = "large_icon";
         public const string SoundKey = "sound";
-        public const string ChannelIdKey = "channel_id";
+        public const string ChannelIdKey = "gcm.notification.android_channel_id";
         public const string ShowWhenKey = "show_when";
         public const string BigTextStyleKey = "bigtextstyle";
 

--- a/Plugin.FirebasePushNotifications/Plugin.FirebasePushNotifications.csproj
+++ b/Plugin.FirebasePushNotifications/Plugin.FirebasePushNotifications.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net8.0-android34.0;net8.0-ios17.0</TargetFrameworks>
+		<TargetFrameworks>net9.0;net9.0-android35.0;net9.0-ios18.0</TargetFrameworks>
 		<OutputType>Library</OutputType>
 		<UseMaui>true</UseMaui>
-		<MauiVersion Condition="$(TargetFramework.Contains('net8.0'))">8.0.3</MauiVersion>
+    <MauiVersion Condition="$(TargetFramework.Contains('net9.0'))">9.0.110</MauiVersion>
+		<!--<MauiVersion Condition="$(TargetFramework.Contains('net8.0'))">8.0.3</MauiVersion>-->
 		<!--<MauiVersion Condition="$(TargetFramework.Contains('net7.0'))">7.0.49</MauiVersion>-->
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -23,7 +24,7 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.110" />
   </ItemGroup>
 
 	<!--NuGet package--> 
@@ -117,8 +118,8 @@
     <PackageReference Include="Xamarin.GooglePlayServices.Tasks" Version="118.0.2.3" />
 
     <!--Temporary workaround for issue in AndroidX: https://github.com/xamarin/AndroidX/issues/742-->
-    <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.7.2.1" />
-    <PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.7.2.1" />
+    <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.10.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.10.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">

--- a/Plugin.FirebasePushNotifications/Plugin.FirebasePushNotifications.csproj
+++ b/Plugin.FirebasePushNotifications/Plugin.FirebasePushNotifications.csproj
@@ -22,6 +22,10 @@
 		<Platforms>AnyCPU;Simulator;Device</Platforms>
 	</PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.3" />
+  </ItemGroup>
+
 	<!--NuGet package--> 
 	<PropertyGroup>
 		<Product>Plugin.FirebasePushNotifications</Product>

--- a/Plugin.FirebasePushNotifications/Plugin.FirebasePushNotifications.csproj
+++ b/Plugin.FirebasePushNotifications/Plugin.FirebasePushNotifications.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net7.0-android33.0;net7.0-ios;net8.0;net8.0-android34.0;net8.0-ios17.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net8.0-android34.0;net8.0-ios17.0</TargetFrameworks>
 		<OutputType>Library</OutputType>
 		<UseMaui>true</UseMaui>
 		<MauiVersion Condition="$(TargetFramework.Contains('net8.0'))">8.0.3</MauiVersion>
-		<MauiVersion Condition="$(TargetFramework.Contains('net7.0'))">7.0.49</MauiVersion>
+		<!--<MauiVersion Condition="$(TargetFramework.Contains('net7.0'))">7.0.49</MauiVersion>-->
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>disable</Nullable>


### PR DESCRIPTION
Updated Android Constants.cs to have the correct Firebase Channel ID

#### Description
Firebase updated the ChannelID key in the key value pair it transmits for push notifications.

```
        //Old Channel ID Key
        //public const string ChannelIdKey = "channel_id";
        //FCM now uses prefix gcm.notification.android_ for certain fields
        public const string ChannelIdKey = "gcm.notification.android_channel_id";
```


#### Issues
Github Issue #141 
Push Notifications not routed to correct Channel ID
* 


